### PR TITLE
Add resilient `copyText` helper, replace inline clipboard calls, UI fixes and version bumps

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mtg-panel-backend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mtg-adminpanel-frontend",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mtg-adminpanel-frontend",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "dependencies": {
         "qrcode.react": "^3.1.0",
         "react": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,16 +1,16 @@
 {
   "name": "mtg-adminpanel-frontend",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
-    "dev":   "vite",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "react":      "^18.3.1",
-    "react-dom":  "^18.3.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "qrcode.react": "^3.1.0"
   },
   "devDependencies": {

--- a/frontend/src/components/AllUsers.jsx
+++ b/frontend/src/components/AllUsers.jsx
@@ -1,10 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api.js';
 import { toast } from '../toast.jsx';
-import { flagUrl, expiryBadge, fmtBytes } from '../utils.jsx';
+import { flagUrl, expiryBadge, fmtBytes, copyText } from '../utils.jsx';
 import * as I from '../icons.jsx';
-
-const copyText = (txt) => navigator.clipboard.writeText(txt).then(() => toast('Скопировано!', 'success'));
 
 export default function AllUsers({ nodes, onSelectNode }) {
   const [groups, setGroups]         = useState({});
@@ -36,6 +34,15 @@ export default function AllUsers({ nodes, onSelectNode }) {
   const totalUsers  = Object.values(groups).reduce((a, u) => a + u.length, 0);
   const totalOnline = Object.values(groups).reduce((a, u) => a + u.filter(x => x.is_online).length, 0);
   const totalActive = Object.values(groups).reduce((a, u) => a + u.filter(x => x.running).length, 0);
+
+  const copyLink = async (txt) => {
+    try {
+      await copyText(txt);
+      toast('Скопировано!', 'success');
+    } catch {
+      toast('Не удалось скопировать. Зажми ссылку и скопируй вручную.', 'error');
+    }
+  };
 
   return (
     <div className="pg">
@@ -137,7 +144,7 @@ export default function AllUsers({ nodes, onSelectNode }) {
                             </td>
                             <td>
                               <div className="acts">
-                                <button className="btn btn-icon btn-secondary btn-sm" onClick={() => copyText(u.link)} title="Копировать ссылку"><I.Copy/></button>
+                                <button className="btn btn-icon btn-secondary btn-sm" onClick={() => copyLink(u.link)} title="Копировать ссылку"><I.Copy/></button>
                               </div>
                             </td>
                           </tr>

--- a/frontend/src/components/NodeModal.jsx
+++ b/frontend/src/components/NodeModal.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { api } from '../api.js';
 import { toast } from '../toast.jsx';
+import { copyText } from '../utils.jsx';
 import FlagPicker from './FlagPicker.jsx';
 import * as I from '../icons.jsx';
 
@@ -58,6 +59,15 @@ export default function NodeModal({ node, onClose, onSave }) {
   };
 
   const installCmd = `mkdir -p /opt/mtg-agent && cd /opt/mtg-agent && curl -fsSL https://raw.githubusercontent.com/MaksimTMB/mtg-adminpanel/dev/mtg-agent/install-agent.sh | bash`;
+
+  const copyInstallCmd = async () => {
+    try {
+      await copyText(installCmd);
+      toast('Скопировано!', 'success');
+    } catch {
+      toast('Не удалось скопировать. Скопируй команду вручную.', 'error');
+    }
+  };
 
   return (
     <div className="overlay" onClick={e => e.target === e.currentTarget && onClose()}>
@@ -144,8 +154,7 @@ export default function NodeModal({ node, onClose, onSave }) {
                     lineHeight:1.6,background:'var(--bg)',padding:'8px 10px',borderRadius:7,border:'1px solid var(--b1)'}}>
                     {installCmd}
                   </code>
-                  <button className="btn btn-ghost btn-sm" style={{flexShrink:0}}
-                    onClick={() => navigator.clipboard.writeText(installCmd).then(() => toast('Скопировано!','success'))}>
+                  <button className="btn btn-ghost btn-sm" style={{flexShrink:0}} onClick={copyInstallCmd}>
                     <I.Copy/>
                   </button>
                 </div>

--- a/frontend/src/components/NodePage.jsx
+++ b/frontend/src/components/NodePage.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api.js';
 import { toast } from '../toast.jsx';
-import { flagUrl, expiryBadge } from '../utils.jsx';
+import { flagUrl, expiryBadge, copyText } from '../utils.jsx';
 import StatPill from './StatPill.jsx';
 import NodeModal from './NodeModal.jsx';
 import * as I from '../icons.jsx';
@@ -28,6 +28,15 @@ export default function NodePage({ node, onBack, onManage, onReload }) {
     const t = setInterval(loadData, 20000);
     return () => clearInterval(t);
   }, [loadData]);
+
+  const copyLink = async (txt) => {
+    try {
+      await copyText(txt);
+      toast('Скопировано!', 'success');
+    } catch {
+      toast('Не удалось скопировать. Зажми ссылку и скопируй вручную.', 'error');
+    }
+  };
 
   const isOnline    = status ? status.online : null;
   const active      = users.filter(u => u.running).length;
@@ -106,7 +115,7 @@ export default function NodePage({ node, onBack, onManage, onReload }) {
                       <td>{expiryBadge(u.expires_at)}</td>
                       <td>
                         <div className="acts">
-                          <button className="btn btn-icon btn-secondary btn-sm" onClick={() => navigator.clipboard.writeText(u.link).then(() => toast('Скопировано!','success'))} title="Копировать ссылку"><I.Copy/></button>
+                          <button className="btn btn-icon btn-secondary btn-sm" onClick={() => copyLink(u.link)} title="Копировать ссылку"><I.Copy/></button>
                           <button className="btn btn-icon btn-secondary btn-sm" onClick={() => onManage(node)} title="Управление клиентом"><I.Edit/></button>
                         </div>
                       </td>

--- a/frontend/src/components/QRModal.jsx
+++ b/frontend/src/components/QRModal.jsx
@@ -1,9 +1,18 @@
 import { QRCodeSVG } from 'qrcode.react';
 import { toast } from '../toast.jsx';
+import { copyText } from '../utils.jsx';
 import * as I from '../icons.jsx';
 
 export default function QRModal({ user, onClose }) {
-  const copy = () => navigator.clipboard.writeText(user.link).then(() => toast('Скопировано!', 'success'));
+  const copy = async () => {
+    try {
+      await copyText(user.link);
+      toast('Скопировано!', 'success');
+    } catch {
+      toast('Не удалось скопировать. Зажми ссылку и скопируй вручную.', 'error');
+    }
+  };
+
   return (
     <div className="overlay" onClick={e => e.target === e.currentTarget && onClose()}>
       <div className="modal" style={{maxWidth:320}}>
@@ -15,9 +24,9 @@ export default function QRModal({ user, onClose }) {
           <div style={{display:'inline-block',padding:16,background:'#fff',borderRadius:12,marginBottom:14}}>
             <QRCodeSVG value={user.link} size={200} level="M"/>
           </div>
-          <div className="link-box" style={{maxWidth:'100%',justifyContent:'center'}} onClick={copy}>
+          <button type="button" className="link-box" style={{maxWidth:'100%',justifyContent:'center',width:'100%'}} onClick={copy}>
             <I.Copy/><span className="link-txt">{user.link}</span>
-          </div>
+          </button>
           <p style={{fontSize:11,color:'var(--t3)',marginTop:8}}>Нажми на ссылку чтобы скопировать</p>
         </div>
         <div className="modal-foot">

--- a/frontend/src/components/UsersPage.jsx
+++ b/frontend/src/components/UsersPage.jsx
@@ -1,13 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api.js';
 import { toast } from '../toast.jsx';
-import { flagUrl, expiryBadge, fmtBytes } from '../utils.jsx';
+import { flagUrl, expiryBadge, fmtBytes, copyText } from '../utils.jsx';
 import AddUserModal from './AddUserModal.jsx';
 import EditModal from './EditModal.jsx';
 import QRModal from './QRModal.jsx';
 import * as I from '../icons.jsx';
-
-const copyText = (txt) => navigator.clipboard.writeText(txt).then(() => toast('Скопировано!', 'success'));
 
 export default function UsersPage({ node, onBack }) {
   const [users, setUsers]     = useState([]);
@@ -43,6 +41,15 @@ export default function UsersPage({ node, onBack }) {
       toast(`Синхронизировано: ${r.imported} новых из ${r.total}`, r.imported > 0 ? 'success' : 'info');
       loadUsers(true);
     } catch(e) { toast(e.message, 'error'); }
+  };
+
+  const copyLink = async (txt) => {
+    try {
+      await copyText(txt);
+      toast('Скопировано!', 'success');
+    } catch {
+      toast('Не удалось скопировать. Зажми ссылку и скопируй вручную.', 'error');
+    }
   };
 
   // Single polling interval — users endpoint now includes traffic
@@ -207,7 +214,7 @@ export default function UsersPage({ node, onBack }) {
                             onClick={() => toggle(u)} disabled={busy[u.name]} title={u.running ? 'Остановить' : 'Запустить'}>
                             {busy[u.name] ? <span className="spin spin-sm"/> : (u.running ? <I.Pause/> : <I.Play/>)}
                           </button>
-                          <button className="btn btn-icon btn-secondary btn-sm" onClick={() => copyText(u.link)} title="Копировать ссылку"><I.Copy/></button>
+                          <button className="btn btn-icon btn-secondary btn-sm" onClick={() => copyLink(u.link)} title="Копировать ссылку"><I.Copy/></button>
                           <button className="btn btn-icon btn-secondary btn-sm" onClick={() => setQrU(u)} title="QR-код"><I.QrCode/></button>
                           <button className="btn btn-icon btn-secondary btn-sm" onClick={() => setEditU(u)} title="Редактировать"><I.Edit/></button>
                           <button className="btn btn-icon btn-secondary btn-sm" onClick={() => resetTraffic(u)}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -295,6 +295,7 @@ tbody tr:hover td { background: rgba(124,111,247,0.04); }
   border: 1px solid var(--b1); border-radius: 7px; padding: 6px 10px;
   font-family: var(--mono); font-size: 11px; color: var(--cy);
   cursor: pointer; transition: all var(--tx); max-width: 280px;
+  appearance: none; -webkit-appearance: none; text-align: left; width: auto;
 }
 .link-box:hover { border-color: var(--vi); background: var(--card); }
 .link-box svg { width: 11px; height: 11px; flex-shrink: 0; }

--- a/frontend/src/utils.jsx
+++ b/frontend/src/utils.jsx
@@ -1,10 +1,54 @@
 export const flagUrl = (code, size = 'w40') =>
   code ? `https://flagcdn.com/${size}/${code}.png` : null;
 
-export const copyText = (txt) =>
-  navigator.clipboard.writeText(txt).then(() => {
-    // toast imported dynamically to avoid circular deps — caller handles it
-  });
+export async function copyText(txt) {
+  if (navigator.clipboard?.writeText && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(txt);
+      return true;
+    } catch {}
+  }
+
+  const input = document.createElement('textarea');
+  input.value = txt;
+  input.setAttribute('readonly', '');
+  input.style.position = 'fixed';
+  input.style.top = '0';
+  input.style.left = '0';
+  input.style.opacity = '0';
+  input.style.pointerEvents = 'none';
+
+  document.body.appendChild(input);
+
+  const selection = document.getSelection();
+  const savedRanges = [];
+
+  if (selection) {
+    for (let i = 0; i < selection.rangeCount; i++) {
+      savedRanges.push(selection.getRangeAt(i).cloneRange());
+    }
+  }
+
+  input.focus({ preventScroll: true });
+  input.select();
+  input.setSelectionRange(0, input.value.length);
+
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } catch {}
+
+  document.body.removeChild(input);
+
+  if (selection) {
+    selection.removeAllRanges();
+    savedRanges.forEach(range => selection.addRange(range));
+  }
+
+  if (copied) return true;
+
+  throw new Error('copy_failed');
+}
 
 export function expiryBadge(expires_at, small) {
   if (!expires_at) return <span style={{color:'var(--t3)',fontSize:small?11:12}}>∞</span>;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "mtg-adminpanel",
-  "version": "1.6.0",
+  "version": "2.1.1",
   "description": "MTG Proxy AdminPanel"
 }


### PR DESCRIPTION
### Motivation
- Provide a single robust clipboard helper with fallback for environments where `navigator.clipboard` is unavailable or insecure, and unify copy-related UX across the app. 
- Improve accessibility and reliability when copying links and install commands from various modals and lists, and bump package versions to reflect the release.

### Description
- Added `copyText` in `frontend/src/utils.jsx` which uses `navigator.clipboard.writeText` when available and falls back to a textarea + `document.execCommand('copy')` approach, preserving selection state and throwing on failure. 
- Replaced ad-hoc `navigator.clipboard.writeText` usages with the new `copyText` wrapper in `AllUsers.jsx`, `NodeModal.jsx`, `NodePage.jsx`, `QRModal.jsx`, and `UsersPage.jsx`, and added `copyLink`/`copyInstallCmd` helpers that surface success/error toasts. 
- Converted the QR modal link container to a button for better semantics and click behavior, and updated `.link-box` CSS to support button appearance and alignment. 
- Bumped versions in `package.json` files (`package.json`, `backend/package.json`, `frontend/package.json`, and `frontend/package-lock.json`) to `2.1.1`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb692884fc832fb7743f2f59a1147d)