### PR TITLE
fix(install): проверять и ставить docker-compose-plugin (#20)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,24 @@ else
     print_ok "Docker уже установлен ($(docker --version | cut -d' ' -f3 | tr -d ','))"
 fi
 
+# ── Установка Docker Compose v2 (плагин) ─────────────────────
+# get.docker.com ставит плагин вместе с Docker, но если Docker уже
+# был установлен из репозитория дистрибутива, плагина может не быть —
+# тогда `docker compose` падает с `unknown shorthand flag: 'd'`.
+if ! docker compose version &> /dev/null; then
+    print_step "Установка Docker Compose v2..."
+    apt-get install -y -qq docker-compose-plugin
+    if docker compose version &> /dev/null; then
+        print_ok "Docker Compose установлен ($(docker compose version --short))"
+    else
+        print_error "Не удалось установить docker-compose-plugin."
+        print_error "Установи его вручную и запусти скрипт повторно: https://docs.docker.com/compose/install/"
+        exit 1
+    fi
+else
+    print_ok "Docker Compose уже установлен ($(docker compose version --short))"
+fi
+
 # ── Клонирование репозитория ─────────────────────────────────
 print_step "Загрузка MTG AdminPanel..."
 if [ -d "$INSTALL_DIR" ]; then
@@ -167,7 +185,8 @@ sleep 3
 if docker ps | grep -q mtg-panel; then
     print_ok "Панель запущена"
 else
-    print_error "Ошибка запуска! Проверь: docker logs mtg-panel"
+    print_error "Ошибка запуска! Логи запуска:"
+    docker compose logs --tail 30 2>&1 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Что чинит
Fixes #20

### Причина
На хостах, где Docker уже был установлен из репозитория дистрибутива (без плагина **Compose v2**), команда `docker compose up -d --build` не распознаётся, и `-d` падает с `unknown shorthand flag: 'd'`. Контейнер не стартует, а обработчик ошибки советует `docker logs mtg-panel` — но контейнера нет, отсюда `No such container: mtg-panel`. `get.docker.com` ставит плагин сам, но ветка «Docker уже установлен» эту проверку пропускала.

### Что сделано (`install.sh`)
- Добавлена проверка `docker compose version` сразу после блока установки Docker — по аналогии с тем, как обрабатывается сам Docker. Если плагина нет, ставим `docker-compose-plugin`; если установить не удалось — внятная ошибка со ссылкой на доки, без попытки запуска.
- Сообщение об ошибке запуска теперь выводит `docker compose logs --tail 30` вместо отсылки к несуществующему контейнеру `mtg-panel`.

### Проверка
- [ ] Чистая Ubuntu без Docker → установка проходит (плагин приезжает с `get.docker.com`)
- [ ] Хост с Docker из distro-репо без плагина → скрипт доставляет `docker-compose-plugin` и запускается
- [ ] Хост с уже установленным плагином → шаг проходит как «уже установлен»

⚠️ Вручную на чистых VM не прогонял (нет окружения) — нужен ручной прогон чек-листа.
